### PR TITLE
Reformat bill-analysis to have both qualitative and quantitative scoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+.venv/*
+.env
+.python-version
+*.pyc

--- a/canadian-legislation-dataset/bill-analysis.ipynb
+++ b/canadian-legislation-dataset/bill-analysis.ipynb
@@ -11,12 +11,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
@@ -26,25 +22,23 @@
     "import openai\n",
     "from dotenv import load_dotenv\n",
     "import os\n",
+    "from langchain.output_parsers import PydanticOutputParser\n",
+    "from pydantic import BaseModel, Field\n",
     "from langchain.output_parsers import EnumOutputParser\n",
     "from enum import Enum\n",
     "\n",
+    "# load the .env file\n",
     "load_dotenv()\n",
     "openai_api_key = os.getenv('OPENAI_API_KEY')\n",
     "openai.api_key = openai_api_key\n",
     "\n",
-    "class ImportanceLevel(str, Enum):\n",
-    "    LOW = \"LOW\"\n",
-    "    MEDIUM = \"MEDIUM\"\n",
-    "    HIGH = \"HIGH\"\n",
-    "\n",
-    "parser = EnumOutputParser(enum=ImportanceLevel)\n",
-    "\n",
-    "with open(\"canadian-legislation-dataset/detailed_bills_with_full_text.json\", \"r\", encoding=\"utf-8\") as file:\n",
+    "# load the bill data\n",
+    "with open(\"detailed_bills_with_full_text.json\", \"r\", encoding=\"utf-8\") as file:\n",
     "    bills_data = json.load(file)\n",
     "\n",
     "full_text = bills_data[0]['full_text'] \n",
     "\n",
+    "# split bill into chunks\n",
     "text_splitter = RecursiveCharacterTextSplitter(\n",
     "    chunk_size=1000,\n",
     "    chunk_overlap=200,  \n",
@@ -52,7 +46,27 @@
     "    is_separator_regex=False,  \n",
     ")\n",
     "\n",
-    "chunks = text_splitter.split_text(full_text)\n",
+    "chunks = text_splitter.split_text(full_text)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Qualitative level using EnumOutputParser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ImportanceLevel(str, Enum):\n",
+    "    LOW = \"LOW\"\n",
+    "    MEDIUM = \"MEDIUM\"\n",
+    "    HIGH = \"HIGH\"\n",
+    "parser = EnumOutputParser(enum=ImportanceLevel)\n",
     "\n",
     "llm = ChatOpenAI(model=\"gpt-4o-mini\", openai_api_key=openai_api_key, temperature=0.2)\n",
     "\n",
@@ -62,17 +76,149 @@
     "Here is the section of the bill:\n",
     "{text}\n",
     "\n",
-    "Classify the importance as either LOW, MEDIUM, or HIGH (respond with only one of these words):\n",
+    "Classify the importance as either LOW, MEDIUM, or HIGH. Respond with only one of these words.\n",
+    "\"\"\"\n",
+    "\n",
+    "prompt = PromptTemplate(input_variables=[\"text\"], template=prompt_template)\n",
+    "\n",
+    "def analyze_importance_level(chunk):\n",
+    "    formatted_prompt = prompt.format(text=chunk)\n",
+    "    result = llm.invoke(formatted_prompt).content\n",
+    "    importance_level = parser.parse(result.strip())\n",
+    "    return importance_level"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Rank one chunk (for testing)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chunk Text Preview: ENGLISH\n",
+      "Cover\n",
+      "Cover\n",
+      "Summary\n",
+      "Summary\n",
+      "BILL C-79\n",
+      "BILL C-79\n",
+      "First Session, Forty-fourth Parliament,\n",
+      "70-7...\n",
+      "Importance Level: MEDIUM\n"
+     ]
+    }
+   ],
+   "source": [
+    "importance_level = analyze_importance_level(chunks[18])\n",
+    "print(f\"Chunk Text Preview: {chunks[0][:100]}...\")\n",
+    "print(f\"Importance Level: {importance_level}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Quantitative score using PydanticOutputParser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pydantic model for the response\n",
+    "class ImportanceScore(BaseModel):\n",
+    "    score: float = Field(..., ge=0, le=100, description=\"Quantitative importance score as a percentage (0 to 100).\")\n",
+    "\n",
+    "# PydanticOutputParser\n",
+    "parser = PydanticOutputParser(pydantic_object=ImportanceScore)\n",
+    "\n",
+    "# initialize LLM\n",
+    "llm = ChatOpenAI(model=\"gpt-4o-mini\", openai_api_key=openai_api_key, temperature=0.2)\n",
+    "\n",
+    "prompt_template = \"\"\"\n",
+    "You are a legislative assistant tasked with analyzing sections of a bill. Your goal is to assess the importance of the given section in deciding whether the bill should be passed.\n",
+    "\n",
+    "Here is the section of the bill:\n",
+    "{text}\n",
+    "\n",
+    "Provide a quantitative importance score as a percentage (0% to 100%) where:\n",
+    "- 0% means the section has no importance in deciding whether the bill should pass.\n",
+    "- 100% means the section is crucial for the bill's decision.\n",
+    "Respond with only the numeric percentage (no text).\n",
+    "\n",
+    "Respond in valid JSON format as follows:\n",
+    "{{ \"score\": <percentage_value> }}\n",
     "\"\"\"\n",
     "\n",
     "prompt = PromptTemplate(input_variables=[\"text\"], template=prompt_template)\n",
     "\n",
     "def analyze_importance(chunk):\n",
+    "    \"\"\"Analyze the importance of a bill chunk using LLM.\"\"\"\n",
     "    formatted_prompt = prompt.format(text=chunk)\n",
-    "    result = llm.invoke(formatted_prompt).content\n",
-    "    importance = parser.parse(result.strip())\n",
-    "    return importance\n",
-    "\n",
+    "    result = llm.invoke(formatted_prompt).content.strip()\n",
+    "    # importance = parser.parse(result.strip())\n",
+    "    return parser.parse(result).score\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Quantify one chunk (for testing)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chunk Text Preview: ENGLISH\n",
+      "Cover\n",
+      "Cover\n",
+      "Summary\n",
+      "Summary\n",
+      "BILL C-79\n",
+      "BILL C-79\n",
+      "First Session, Forty-fourth Parliament,\n",
+      "70-7...\n",
+      "Importance Score: 65.0%\n"
+     ]
+    }
+   ],
+   "source": [
+    "importance = analyze_importance(chunks[18])\n",
+    "print(f\"Chunk Text Preview: {chunks[0][:100]}...\")\n",
+    "print(f\"Importance Score: {importance}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Quantify all chunks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "importances = [analyze_importance(chunk) for chunk in chunks]\n",
     "\n",
     "for i, (chunk, importance) in enumerate(zip(chunks, importances)):\n",
@@ -83,8 +229,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changes:
- Split the bill-analysis notebook into smaller sections for clarity
- Added a section that uses PydanticOutputParser to quantify the importance of each bill chunk

Warnings:
- There are currently sections that are only for testing individual chunks